### PR TITLE
chore: add olaunch update script

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -53,6 +53,13 @@ jobs:
         run: |
           python scripts/update-claudio.py
 
+      - name: Update olaunch formula
+        id: update-olaunch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/update-olaunch.py
+
       - name: Update navigit formula
         id: update-navigit
         env:

--- a/Formula/olaunch.rb
+++ b/Formula/olaunch.rb
@@ -1,9 +1,10 @@
 class Olaunch < Formula
   desc "Open launcher for local/open model coding agents"
   homepage "https://github.com/scaryrawr/olaunch"
-  url "https://github.com/scaryrawr/olaunch/releases/download/v0.0.1/olaunch-v0.0.1-aarch64-apple-darwin.tar.gz"
-  sha256 "1ddd1366a0f0b2e18ffe5a4465190e154472e6962e0dab098996a47b051dd9fb"
-  # Upstream v0.0.1 does not publish license metadata.
+  url "https://github.com/scaryrawr/olaunch/releases/download/v0.1.1/olaunch-v0.1.1-aarch64-apple-darwin.tar.gz"
+  version "0.1.1"
+  sha256 "de2ecbb476d05512107e66deb71accc460785fe69de01e09774b69426995abf9"
+  # Upstream does not publish license metadata.
   license :cannot_represent
 
   on_macos do
@@ -13,12 +14,12 @@ class Olaunch < Formula
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/scaryrawr/olaunch/releases/download/v0.0.1/olaunch-v0.0.1-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "5db18842fa5d3e3fa4933ef49910d6a9444b3fc0698f79b7f5d173d398ccb4f2"
+      url "https://github.com/scaryrawr/olaunch/releases/download/v0.1.1/olaunch-v0.1.1-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "0cf8c7dff18c70d9077bd49c585b3b8bff202bdb191fae7ecc1ff729269554a0"
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/scaryrawr/olaunch/releases/download/v0.0.1/olaunch-v0.0.1-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "338e1214987855e054592f4f8375a88b8f925e2319845ef1b86fba69c7f18dfb"
+      url "https://github.com/scaryrawr/olaunch/releases/download/v0.1.1/olaunch-v0.1.1-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "f9763f5065aab6a40c98704335452ccdd55749a115d497ad1804d7ebb257a415"
     end
   end
 

--- a/Formula/olaunch.rb
+++ b/Formula/olaunch.rb
@@ -2,7 +2,6 @@ class Olaunch < Formula
   desc "Open launcher for local/open model coding agents"
   homepage "https://github.com/scaryrawr/olaunch"
   url "https://github.com/scaryrawr/olaunch/releases/download/v0.1.1/olaunch-v0.1.1-aarch64-apple-darwin.tar.gz"
-  version "0.1.1"
   sha256 "de2ecbb476d05512107e66deb71accc460785fe69de01e09774b69426995abf9"
   # Upstream does not publish license metadata.
   license :cannot_represent

--- a/scripts/update-olaunch.py
+++ b/scripts/update-olaunch.py
@@ -61,7 +61,7 @@ def update_olaunch_formula():
                 return False
             current_version = url_match.group(1).lstrip("v")
 
-        if version_match and current_version == latest_version:
+        if current_version == latest_version:
             print(f"olaunch is already up to date at {latest_version}")
             return False
 
@@ -90,12 +90,7 @@ def update_olaunch_formula():
                 count=1,
             )
         else:
-            new_content = re.sub(
-                r'(url "https://github\.com/scaryrawr/olaunch/releases/download/[^"]+"\n)',
-                rf'\1  version "{latest_version}"\n',
-                content,
-                count=1,
-            )
+            new_content = content
 
         for target, new_url, new_sha256 in updates:
             url_sha_regex = re.compile(

--- a/scripts/update-olaunch.py
+++ b/scripts/update-olaunch.py
@@ -88,25 +88,22 @@ def update_olaunch_formula():
             print(f"Updated {target}: {new_sha256}")
             updates.append((target, new_url, new_sha256))
 
-        if version_match:
-            new_content = re.sub(
-                r'version "[^"]+"',
-                f'version "{latest_version}"',
-                content,
-                count=1,
-            )
-        else:
-            new_content = content
+        new_content = re.sub(
+            r'^\s*version "[^"]+"\n',
+            "",
+            content,
+            count=1,
+            flags=re.MULTILINE,
+        )
 
         for target, new_url, new_sha256 in updates:
             url_sha_regex = re.compile(
                 rf'url "https://github\.com/scaryrawr/olaunch/releases/download/[^/]+/olaunch-[^"]+-{re.escape(target)}\.tar\.gz"\n'
-                r'((?:\s*version "[^"]+"\n)?)(\s*)sha256 "[^"]+"',
+                r'(?:\s*version "[^"]+"\n)?(\s*)sha256 "[^"]+"',
                 re.MULTILINE,
             )
             new_content, replacements = url_sha_regex.subn(
-                lambda m: f'url "{new_url}"\n{m.group(1)}'
-                f'{m.group(2)}sha256 "{new_sha256}"',
+                lambda m: f'url "{new_url}"\n{m.group(1)}sha256 "{new_sha256}"',
                 new_content,
                 count=1,
             )

--- a/scripts/update-olaunch.py
+++ b/scripts/update-olaunch.py
@@ -10,7 +10,12 @@ def get_sha256(url):
     """Download file and calculate SHA256 checksum using curl."""
     with tempfile.NamedTemporaryFile() as temp_file:
         try:
-            subprocess.run(["curl", "-sL", url, "-o", temp_file.name], check=True)
+            subprocess.run(
+                ["curl", "-fsSL", url, "-o", temp_file.name],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
             sha256_hash = hashlib.sha256()
             with open(temp_file.name, "rb") as f:
@@ -19,7 +24,8 @@ def get_sha256(url):
 
             return sha256_hash.hexdigest()
         except subprocess.CalledProcessError as e:
-            raise Exception(f"Failed to download {url}: {e}")
+            details = e.stderr.strip() if e.stderr else str(e)
+            raise Exception(f"Failed to download {url}: {details}")
 
 
 def get_latest_release(repo):

--- a/scripts/update-olaunch.py
+++ b/scripts/update-olaunch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import hashlib
+import re
+import subprocess
+import tempfile
+
+
+def get_sha256(url):
+    """Download file and calculate SHA256 checksum using curl."""
+    with tempfile.NamedTemporaryFile() as temp_file:
+        try:
+            subprocess.run(["curl", "-sL", url, "-o", temp_file.name], check=True)
+
+            sha256_hash = hashlib.sha256()
+            with open(temp_file.name, "rb") as f:
+                for chunk in iter(lambda: f.read(8192), b""):
+                    sha256_hash.update(chunk)
+
+            return sha256_hash.hexdigest()
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Failed to download {url}: {e}")
+
+
+def get_latest_release(repo):
+    """Get the latest release tag from GitHub using gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/latest", "--jq", ".tag_name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Failed to get latest release for {repo}: {e}")
+
+
+def update_olaunch_formula():
+    """Update the olaunch formula with latest release."""
+    repo = "scaryrawr/olaunch"
+    formula_path = "Formula/olaunch.rb"
+
+    try:
+        latest_tag = get_latest_release(repo)
+        latest_version = latest_tag.lstrip("v")
+
+        with open(formula_path, "r") as f:
+            content = f.read()
+
+        version_match = re.search(r'version "([^"]+)"', content)
+        if version_match:
+            current_version = version_match.group(1)
+        else:
+            url_match = re.search(
+                r'url "https://github\.com/scaryrawr/olaunch/releases/download/([^/]+)/',
+                content,
+            )
+            if not url_match:
+                print("Could not find version or URL in olaunch.rb")
+                return False
+            current_version = url_match.group(1).lstrip("v")
+
+        if version_match and current_version == latest_version:
+            print(f"olaunch is already up to date at {latest_version}")
+            return False
+
+        targets = [
+            "aarch64-apple-darwin",
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+        ]
+
+        updates = []
+        for target in targets:
+            asset_name = f"olaunch-{latest_tag}-{target}.tar.gz"
+            new_url = (
+                f"https://github.com/scaryrawr/olaunch/releases/download/{latest_tag}/"
+                f"{asset_name}"
+            )
+            new_sha256 = get_sha256(new_url)
+            print(f"Updated {target}: {new_sha256}")
+            updates.append((target, new_url, new_sha256))
+
+        if version_match:
+            new_content = re.sub(
+                r'version "[^"]+"',
+                f'version "{latest_version}"',
+                content,
+                count=1,
+            )
+        else:
+            new_content = re.sub(
+                r'(url "https://github\.com/scaryrawr/olaunch/releases/download/[^"]+"\n)',
+                rf'\1  version "{latest_version}"\n',
+                content,
+                count=1,
+            )
+
+        for target, new_url, new_sha256 in updates:
+            url_sha_regex = re.compile(
+                rf'url "https://github\.com/scaryrawr/olaunch/releases/download/[^/]+/olaunch-[^"]+-{re.escape(target)}\.tar\.gz"\n'
+                r'((?:\s*version "[^"]+"\n)?)(\s*)sha256 "[^"]+"',
+                re.MULTILINE,
+            )
+            new_content, replacements = url_sha_regex.subn(
+                lambda m: f'url "{new_url}"\n{m.group(1)}'
+                f'{m.group(2)}sha256 "{new_sha256}"',
+                new_content,
+                count=1,
+            )
+            if replacements != 1:
+                raise Exception(f"Could not update URL and sha256 for {target}")
+
+        with open(formula_path, "w") as f:
+            f.write(new_content)
+
+        print(f"Updated olaunch from {current_version} to {latest_version}")
+        return True
+
+    except Exception as e:
+        print(f"Error updating olaunch: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    update_olaunch_formula()


### PR DESCRIPTION
Adds an automated updater for the olaunch formula and wires it into the scheduled formula update workflow.\n\nValidation:\n- python3 scripts/update-olaunch.py\n- brew test-bot --only-tap-syntax