### PR TITLE
Fix omlx HEAD reinstall linkage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,7 @@ end
 
 - `Formula/omlx.rb` is a head-only formula for the unstable custom `scaryrawr/omlx` fork. Upstream `jundot/omlx` formula changes are useful references, but keep the local formula pointed at the fork unless instructed otherwise.
 - `omlx` installs optional `mlx-audio` from a pinned source resource. When updating that pin, recalculate the tarball SHA256 and inspect `mlx-audio`'s dependency metadata before keeping or adding `inreplace` patches.
+- `omlx` forces selected native Python packages, including `watchfiles`, to build from source with headerpad linker flags so Homebrew can rewrite Mach-O install names during `brew reinstall --HEAD`; do not remove them from `PIP_NO_BINARY` without retesting that linkage fix.
 
 ## Update Script Pattern
 

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -51,14 +51,14 @@ class Omlx < Formula
 
     # Build native extensions from source with headerpad so Homebrew can
     # rewrite Mach-O install names to absolute Cellar/opt paths. Rust/maturin
-    # extension builds (cohere_melody) need the linker flag via RUSTFLAGS;
-    # C/C++ extension builds use LDFLAGS. tokenizers is excluded: its wheel
-    # ships a stable-ABI .abi3.so that does not need Homebrew's dylib ID
-    # rewrite, and building from source fails on macOS 15+ due to PyO3 linker
-    # errors (missing Python symbols at link time).
+    # extension builds (cohere_melody, watchfiles) need the linker flag via
+    # RUSTFLAGS; C/C++ extension builds use LDFLAGS. tokenizers is excluded:
+    # its wheel ships a stable-ABI .abi3.so that does not need Homebrew's
+    # dylib ID rewrite, and building from source fails on macOS 15+ due to
+    # PyO3 linker errors (missing Python symbols at link time).
     ENV.append "LDFLAGS", "-Wl,-headerpad_max_install_names"
     ENV.append "RUSTFLAGS", "-C link-arg=-Wl,-headerpad_max_install_names"
-    ENV["PIP_NO_BINARY"] = "cohere_melody,nh3,pydantic-core,rpds-py,tiktoken"
+    ENV["PIP_NO_BINARY"] = "cohere_melody,nh3,pydantic-core,rpds-py,tiktoken,watchfiles"
     ENV["PIP_NO_CACHE_DIR"] = "1"
 
     extras = []
@@ -82,6 +82,11 @@ class Omlx < Formula
     cohere_ext = Dir["#{site_packages}/cohere_melody/cohere_melody*.so"].first
     odie "cohere_melody extension not found" if cohere_ext.nil?
     rewrite_dylib_id cohere_ext, "#{opt_prefix}/#{Pathname.new(cohere_ext).relative_path_from(prefix)}"
+    watchfiles_ext = Dir["#{site_packages}/watchfiles/_rust_notify*.so"].first
+    odie "watchfiles extension not found" if watchfiles_ext.nil?
+    rewrite_dylib_id watchfiles_ext,
+                     "#{opt_prefix}/#{Pathname.new(watchfiles_ext).relative_path_from(prefix).dirname}/" \
+                     "watchfiles.#{File.basename(watchfiles_ext)}"
     rewrite_install_name "#{site_packages}/mlx/lib/libmlx.dylib",
                          "@rpath/libjaccl.dylib",
                          "@loader_path/libjaccl.dylib"

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -83,8 +83,9 @@ class Omlx < Formula
     odie "cohere_melody extension not found" if cohere_ext.nil?
     rewrite_dylib_id cohere_ext, "#{opt_prefix}/#{Pathname.new(cohere_ext).relative_path_from(prefix)}"
     watchfiles_ext = Dir["#{site_packages}/watchfiles/_rust_notify*.so"].first
-    odie "watchfiles extension not found" if watchfiles_ext.nil?
-    rewrite_dylib_id watchfiles_ext, "#{opt_prefix}/#{Pathname.new(watchfiles_ext).relative_path_from(prefix)}"
+    if watchfiles_ext
+      rewrite_dylib_id watchfiles_ext, "#{opt_prefix}/#{Pathname.new(watchfiles_ext).relative_path_from(prefix)}"
+    end
     rewrite_install_name "#{site_packages}/mlx/lib/libmlx.dylib",
                          "@rpath/libjaccl.dylib",
                          "@loader_path/libjaccl.dylib"

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -84,9 +84,7 @@ class Omlx < Formula
     rewrite_dylib_id cohere_ext, "#{opt_prefix}/#{Pathname.new(cohere_ext).relative_path_from(prefix)}"
     watchfiles_ext = Dir["#{site_packages}/watchfiles/_rust_notify*.so"].first
     odie "watchfiles extension not found" if watchfiles_ext.nil?
-    rewrite_dylib_id watchfiles_ext,
-                     "#{opt_prefix}/#{Pathname.new(watchfiles_ext).relative_path_from(prefix).dirname}/" \
-                     "watchfiles.#{File.basename(watchfiles_ext)}"
+    rewrite_dylib_id watchfiles_ext, "#{opt_prefix}/#{Pathname.new(watchfiles_ext).relative_path_from(prefix)}"
     rewrite_install_name "#{site_packages}/mlx/lib/libmlx.dylib",
                          "@rpath/libjaccl.dylib",
                          "@loader_path/libjaccl.dylib"


### PR DESCRIPTION
`brew reinstall` for the head-only `omlx` formula was failing when Homebrew tried to rewrite the `watchfiles` Rust extension dylib ID. The formula already builds selected native Python packages from source with headerpad linker flags, but `watchfiles` was still coming from a wheel and did not have enough install-name space for Homebrew's relocation pass.

This updates `omlx` to build `watchfiles` from source alongside the other native packages and explicitly rewrites its dylib ID during install, matching the path Homebrew expects under `opt_prefix`. It also records the repo-specific guidance so future formula updates do not accidentally remove `watchfiles` from `PIP_NO_BINARY` without retesting the reinstall linkage behavior.

Validation performed:
- `brew test-bot --only-tap-syntax`
- `ruby -c Formula/omlx.rb`
- `brew style Formula/omlx.rb`
- Reinstalled from a temporary local tap with `--with-image --with-audio --with-grammar`
- Confirmed `watchfiles` dylib ID was rewritten and native imports passed
- Restarted `omlx` and confirmed `/health` responds healthy