### PR TITLE
Add smahtutils Homebrew formula

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,12 @@ brew test <formula>
 brew test-bot --only-formulae
 ```
 
+When working from a Copilot worktree outside Homebrew's tap directory, Homebrew
+may reject `Formula/<formula>.rb` paths. For local install/test validation,
+temporarily symlink the worktree under `$(brew --repository)/Library/Taps/...`,
+run Homebrew with `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`, and remove the symlink
+afterward.
+
 ## Architecture
 
 This is a Homebrew tap with automated version updates:
@@ -65,6 +71,7 @@ end
 - `Formula/omlx.rb` is a head-only formula for the unstable custom `scaryrawr/omlx` fork. Upstream `jundot/omlx` formula changes are useful references, but keep the local formula pointed at the fork unless instructed otherwise.
 - `omlx` installs optional `mlx-audio` from a pinned source resource. When updating that pin, recalculate the tarball SHA256 and inspect `mlx-audio`'s dependency metadata before keeping or adding `inreplace` patches.
 - `omlx` forces selected native Python packages, including `watchfiles`, to build from source with headerpad linker flags so Homebrew can rewrite Mach-O install names during `brew reinstall --HEAD`; do not remove them from `PIP_NO_BINARY` without retesting that linkage fix.
+- For Python formulae that intentionally let pip resolve upstream dependencies instead of vendoring `resource` blocks, use an explicit virtualenv plus `pip install` rather than `Language::Python::Virtualenv#pip_install_and_link`, which installs with `--no-deps`. If native Python extensions fail Homebrew linkage rewriting, force those packages to build from source with headerpad linker flags and add the needed build dependencies.
 
 ## Update Script Pattern
 

--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -67,6 +67,13 @@ jobs:
         run: |
           python scripts/update-navigit.py
 
+      - name: Update smahtutils formula
+        id: update-smahtutils
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/update-smahtutils.py
+
       - name: Check for changes
         id: check-changes
         run: |

--- a/Formula/smahtutils.rb
+++ b/Formula/smahtutils.rb
@@ -6,15 +6,29 @@ class Smahtutils < Formula
   license :cannot_represent
   head "https://github.com/scaryrawr/smahtutils.git", branch: "main"
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "python@3.11"
+
+  on_linux do
+    depends_on "freetype"
+    depends_on "jpeg-turbo"
+    depends_on "libpng"
+    depends_on "libtiff"
+    depends_on "little-cms2"
+    depends_on "openjpeg"
+    depends_on "webp"
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "python3.11", "-m", "venv", libexec
     ENV.append "LDFLAGS", "-Wl,-headerpad_max_install_names"
     ENV.append "RUSTFLAGS", "-C link-arg=-Wl,-headerpad_max_install_names"
     ENV["PIP_NO_CACHE_DIR"] = "1"
-    ENV["PIP_NO_BINARY"] = "annoy,jiter,pydantic-core,rpds-py"
+    no_binary = %w[annoy jiter pydantic-core rpds-py]
+    no_binary << "pillow" if OS.linux?
+    ENV["PIP_NO_BINARY"] = no_binary.join(",")
     system libexec/"bin/pip", "install", buildpath
 
     bin.install_symlink libexec/"bin/smahtiepants"

--- a/Formula/smahtutils.rb
+++ b/Formula/smahtutils.rb
@@ -1,0 +1,39 @@
+class Smahtutils < Formula
+  desc "Small LLM/VLM utilities for local development workflows"
+  homepage "https://github.com/scaryrawr/smahtutils"
+  url "https://github.com/scaryrawr/smahtutils/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "9ef917690c105009b69d5d1f10b02b2b58988242cc3fbbd5a5850f6260942c6e"
+  license :cannot_represent
+  head "https://github.com/scaryrawr/smahtutils.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "python@3.11"
+
+  def install
+    system "python3.11", "-m", "venv", libexec
+    ENV.append "LDFLAGS", "-Wl,-headerpad_max_install_names"
+    ENV.append "RUSTFLAGS", "-C link-arg=-Wl,-headerpad_max_install_names"
+    ENV["PIP_NO_CACHE_DIR"] = "1"
+    ENV["PIP_NO_BINARY"] = "annoy,jiter,pydantic-core,rpds-py"
+    system libexec/"bin/pip", "install", buildpath
+
+    bin.install_symlink libexec/"bin/smahtiepants"
+    bin.install_symlink libexec/"bin/smahties"
+    bin.install_symlink libexec/"bin/wickedpaste"
+  end
+
+  service do
+    run [opt_bin/"smahtiepants", "serve"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/smahtiepants.log"
+    error_log_path var/"log/smahtiepants.log"
+    environment_variables PATH: std_service_path_env
+  end
+
+  test do
+    assert_match "smahtiepants", shell_output("#{bin}/smahtiepants --help")
+    assert_match "smahties", shell_output("#{bin}/smahties --help")
+    assert_match "wickedpaste", shell_output("#{bin}/wickedpaste --help")
+  end
+end

--- a/scripts/update-smahtutils.py
+++ b/scripts/update-smahtutils.py
@@ -10,7 +10,12 @@ def get_sha256(url):
     """Download file and calculate SHA256 checksum using curl."""
     with tempfile.NamedTemporaryFile() as temp_file:
         try:
-            subprocess.run(["curl", "-sL", url, "-o", temp_file.name], check=True)
+            subprocess.run(
+                ["curl", "-fsSL", url, "-o", temp_file.name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
 
             sha256_hash = hashlib.sha256()
             with open(temp_file.name, "rb") as f:
@@ -19,7 +24,25 @@ def get_sha256(url):
 
             return sha256_hash.hexdigest()
         except subprocess.CalledProcessError as e:
-            raise Exception(f"Failed to download {url}: {e}")
+            detail = e.stderr.strip() or str(e)
+            raise Exception(f"Failed to download {url}: {detail}")
+
+
+def get_latest_release(repo):
+    """Get the latest release tag from GitHub using gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/latest", "--jq", ".tag_name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        detail = e.stderr.strip() or e.stdout.strip() or str(e)
+        if "404" in detail or "Not Found" in detail:
+            return None
+        raise Exception(f"Failed to get latest release for {repo}: {detail}")
 
 
 def get_latest_tag(repo):
@@ -33,7 +56,13 @@ def get_latest_tag(repo):
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        raise Exception(f"Failed to get latest tag for {repo}: {e}")
+        detail = e.stderr.strip() or e.stdout.strip() or str(e)
+        raise Exception(f"Failed to get latest tag for {repo}: {detail}")
+
+
+def get_latest_version_tag(repo):
+    """Prefer the latest release tag, falling back to tags for repos without releases."""
+    return get_latest_release(repo) or get_latest_tag(repo)
 
 
 def update_smahtutils_formula():
@@ -42,7 +71,7 @@ def update_smahtutils_formula():
     formula_path = "Formula/smahtutils.rb"
 
     try:
-        latest_tag = get_latest_tag(repo)
+        latest_tag = get_latest_version_tag(repo)
 
         with open(formula_path, "r") as f:
             content = f.read()

--- a/scripts/update-smahtutils.py
+++ b/scripts/update-smahtutils.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import hashlib
+import re
+import subprocess
+import tempfile
+
+
+def get_sha256(url):
+    """Download file and calculate SHA256 checksum using curl."""
+    with tempfile.NamedTemporaryFile() as temp_file:
+        try:
+            subprocess.run(["curl", "-sL", url, "-o", temp_file.name], check=True)
+
+            sha256_hash = hashlib.sha256()
+            with open(temp_file.name, "rb") as f:
+                for chunk in iter(lambda: f.read(8192), b""):
+                    sha256_hash.update(chunk)
+
+            return sha256_hash.hexdigest()
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Failed to download {url}: {e}")
+
+
+def get_latest_tag(repo):
+    """Get the latest tag from GitHub using gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/tags", "--jq", ".[0].name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Failed to get latest tag for {repo}: {e}")
+
+
+def update_smahtutils_formula():
+    """Update the smahtutils formula with latest tag."""
+    repo = "scaryrawr/smahtutils"
+    formula_path = "Formula/smahtutils.rb"
+
+    try:
+        latest_tag = get_latest_tag(repo)
+
+        with open(formula_path, "r") as f:
+            content = f.read()
+
+        url_match = re.search(
+            r'url "https://github\.com/scaryrawr/smahtutils/archive/refs/tags/([^"]+)\.tar\.gz"',
+            content,
+        )
+        if not url_match:
+            print("Could not find URL in smahtutils.rb")
+            return False
+
+        current_tag = url_match.group(1)
+
+        if current_tag == latest_tag:
+            print(f"smahtutils is already up to date at {latest_tag}")
+            return False
+
+        new_url = f"https://github.com/scaryrawr/smahtutils/archive/refs/tags/{latest_tag}.tar.gz"
+        new_sha256 = get_sha256(new_url)
+
+        new_content = re.sub(
+            r'url "https://github\.com/scaryrawr/smahtutils/archive/refs/tags/[^"]+\.tar\.gz"',
+            f'url "{new_url}"',
+            content,
+        )
+        new_content = re.sub(r'sha256 "[^"]+"', f'sha256 "{new_sha256}"', new_content)
+
+        with open(formula_path, "w") as f:
+            f.write(new_content)
+
+        print(f"Updated smahtutils from {current_tag} to {latest_tag}")
+        return True
+
+    except Exception as e:
+        print(f"Error updating smahtutils: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    update_smahtutils_formula()


### PR DESCRIPTION
Adds a Homebrew formula for `scaryrawr/smahtutils` so the tap can install the `smahtiepants`, `smahties`, and `wickedpaste` CLIs, with `smahtiepants serve` registered as a Homebrew service.

The formula installs from the v0.1.0 source tag into an explicit Python 3.11 virtualenv and lets pip resolve upstream dependencies. Native Python extensions that Homebrew needs to rewrite are forced to build from source with headerpad linker flags, matching the tap's existing Python formula pattern for reliable linkage.

Also adds an update script for future smahtutils tags, wires it into the scheduled formula update workflow, and records the worktree tap-validation guidance learned while testing.

Validation performed:
- `brew test-bot --only-tap-syntax`
- `brew install --build-from-source` and `brew test smahtutils` via a temporary tap symlink with `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`
- `brew audit --strict --online --new`
- `brew style Formula/smahtutils.rb`
- `python3 -m py_compile scripts/update-smahtutils.py`