### PR TITLE
Respect Homebrew PyPI proxy for omlx

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -46,6 +46,10 @@ class Omlx < Formula
   end
 
   def install
+    # Homebrew disables user pip configuration inside formula builds. Forward
+    # its supported package-index setting to pip and build-isolation subprocesses.
+    ENV["PIP_INDEX_URL"] = ENV["HOMEBREW_PIP_INDEX_URL"] if ENV["HOMEBREW_PIP_INDEX_URL"].present?
+
     # Create venv with pip so dependency resolution works properly.
     system "python3.11", "-m", "venv", libexec
 


### PR DESCRIPTION
Homebrew sets PIP_CONFIG_FILE=/dev/null; direct pip calls previously fell back to files.pythonhosted.org. The formula now maps HOMEBREW_PIP_INDEX_URL to PIP_INDEX_URL so pip and build-isolation subprocesses use the configured package feed.

Validation: brew reinstall and brew test.